### PR TITLE
Remove hierarchy declaration for MysqlAdapter and MysqlAdapter2 classes redefinition

### DIFF
--- a/lib/trackless_triggers.rb
+++ b/lib/trackless_triggers.rb
@@ -79,6 +79,7 @@ module ActiveRecord
       def triggers(table, name = nil)
         triggers = []
         execute("SHOW TRIGGERS LIKE '#{table}'", name).each do |row|
+          row = row.values if row.is_a?(Hash)
           triggers <<  TriggerDefinition.new(*row)
         end
 
@@ -89,17 +90,16 @@ module ActiveRecord
         function_names = []
         functions = []
 
-        #config = Rails::Application.config
-        #config.database_configuration[RAILS_ENV]["database"]
-        dbname = ActiveRecord::Base.configurations[Rails.env]['database'] 
-
+        dbname = ActiveRecord::Base.configurations[Rails.env]['database']
         execute("SHOW FUNCTION STATUS WHERE DB='#{dbname}'").each do |row|
+          row = row.values if row.is_a?(Hash)
           func_info = FunctionInfoDefinition.new(*row)
           function_names << func_info.name
         end
 
         function_names.each do |name|
           execute("SHOW CREATE FUNCTION #{name}").each do |row|
+            row = row.values if row.is_a?(Hash)
             functions << FunctionDefinition.new(*row)
           end
         end

--- a/lib/trackless_triggers.rb
+++ b/lib/trackless_triggers.rb
@@ -82,11 +82,11 @@ module ActiveRecord
 
     end
 
-    class MysqlAdapter < AbstractMysqlAdapter
+    class MysqlAdapter
       include TriggerFunc
     end
 
-    class Mysql2Adapter < AbstractMysqlAdapter
+    class Mysql2Adapter
       include TriggerFunc
     end
 

--- a/lib/trackless_triggers.rb
+++ b/lib/trackless_triggers.rb
@@ -1,4 +1,16 @@
-require 'active_record/connection_adapters/abstract_mysql_adapter'
+def load_adapter(path)
+  begin
+    require path
+    true
+  rescue LoadError
+    false
+  end
+end
+
+MYSQL_ADAPTER_AVAILABLE = load_adapter 'active_record/connection_adapters/mysql_adapter'
+MYSQL2_ADAPTER_AVAILABLE = load_adapter 'active_record/connection_adapters/mysql2_adapter'
+MYSQL_JDBC_ADAPTER_AVAILABLE = load_adapter 'arjdbc/mysql/adapter'
+
 
 module ActiveRecord
   class SchemaDumper
@@ -23,7 +35,22 @@ module ActiveRecord
     def dump_table_triggers(table, stream)
       triggers = @connection.triggers(table)
       triggers.each do |trigger|
-        stream.print "  add_trigger \"#{trigger.name}\", :on => \"#{trigger.reference_table}\", :timing => \"#{trigger.timing}\", :event => \"#{trigger.event}\", :statement => \"#{trigger.statement}\""
+        name = trigger.name
+        name = name.last if name.is_a? Array
+
+        reference_table = trigger.reference_table
+        reference_table = reference_table.last if reference_table.is_a? Array
+
+        timing = trigger.timing
+        timing = timing.last if timing.is_a? Array
+
+        event = trigger.event
+        event = event.last if event.is_a? Array
+
+        statement = trigger.statement
+        statement = statement.last if statement.is_a? Array
+
+        stream.print "  add_trigger \"#{name}\", :on => \"#{reference_table}\", :timing => \"#{timing}\", :event => \"#{event}\", :statement => \"#{statement}\""
         stream.puts
       end
     end
@@ -84,11 +111,11 @@ module ActiveRecord
 
     class MysqlAdapter
       include TriggerFunc
-    end
+    end if MYSQL_JDBC_ADAPTER_AVAILABLE || MYSQL_ADAPTER_AVAILABLE
 
     class Mysql2Adapter
       include TriggerFunc
-    end
+    end if MYSQL2_ADAPTER_AVAILABLE
 
     module SchemaStatements
       def add_trigger(name, opts = {})


### PR DESCRIPTION
When using this gem in JRuby, we get the following error:

```
TypeError: superclass mismatch for class MysqlAdapter
  ConnectionAdapters at src/trackless_triggers/lib/trackless_triggers.rb:85
        ActiveRecord at src/trackless_triggers/lib/trackless_triggers.rb:41
              (root) at trackless_triggers/lib/trackless_triggers.rb:3
             require at org/jruby/RubyKernel.java:1065
              (root) at .rvm/gems/jruby-1.7.16@global/gems/bundler-1.7.3/lib/bundler/runtime.rb:1
                each at org/jruby/RubyArray.java:1613
             require at .rvm/gems/jruby-1.7.16@global/gems/bundler-1.7.3/lib/bundler/runtime.rb:76
                each at org/jruby/RubyArray.java:1613
             require at .rvm/gems/jruby-1.7.16@global/gems/bundler-1.7.3/lib/bundler/runtime.rb:72
             require at .rvm/gems/jruby-1.7.16@global/gems/bundler-1.7.3/lib/bundler/runtime.rb:61
             require at .rvm/gems/jruby-1.7.16@global/gems/bundler-1.7.3/lib/bundler.rb:133
             require at org/jruby/RubyKernel.java:1065
              (root) at script/rails:6
```

This is caused by the fact that the MysqlAdapter class defined in the activerecord-jdbc-adapter has different hierarchy:
https://github.com/jruby/activerecord-jdbc-adapter/blob/bfab971843d4abd9a818c539645856df021c2c2f/lib/arjdbc/mysql/adapter.rb#L614

This PR fixes this problem.
